### PR TITLE
Fix fake player XP not resetting on death

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -201,6 +201,7 @@ public class EntityPlayerMPFake extends ServerPlayer
         super.die(cause);
         setHealth(20);
         this.foodData = new FoodData();
+        giveExperienceLevels(-(experienceLevel + 1));
         kill(this.getCombatTracker().getDeathMessage());
     }
 


### PR DESCRIPTION
I think this would be a good addition to your carpet PVP tweaks, especially the ones made on fake players, an old friend slinarm made this pull request on this original fabric carpet, but this would be really cool if you could merge this. (My IDE is broken atm so I can't test it but I hope it still works)