### PR TITLE
All requests added

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -129,6 +129,7 @@ public class CarpetServer // static for now - easier to handle all around the co
         LogCommand.register(dispatcher, commandBuildContext);
         SpawnCommand.register(dispatcher, commandBuildContext);
         PlayerCommand.register(dispatcher, commandBuildContext);
+        PlayerSpawnCommand.register(dispatcher, commandBuildContext);
         InfoCommand.register(dispatcher, commandBuildContext);
         DistanceCommand.register(dispatcher, commandBuildContext);
         PerimeterInfoCommand.register(dispatcher, commandBuildContext);

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1040,4 +1040,10 @@ public class CarpetSettings
             category = {SURVIVAL, FEATURE}
     )
     public static boolean shieldStunning = false;
+    
+    @Rule(
+            desc = "Enables editing player nbt, so you can directly edit values within a player's data.",
+            category = {COMMAND, EXPERIMENTAL}
+    )
+    public static boolean editablePlayerNbt = false;
 }

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -1,341 +1,118 @@
 package carpet.commands;
 
+import carpet.CarpetSettings;
+import carpet.fakes.ServerPlayerInterface;
 import carpet.helpers.EntityPlayerActionPack;
 import carpet.helpers.EntityPlayerActionPack.Action;
 import carpet.helpers.EntityPlayerActionPack.ActionType;
-import carpet.CarpetSettings;
-import carpet.fakes.ServerPlayerInterface;
 import carpet.patches.EntityPlayerMPFake;
 import carpet.utils.CommandHelper;
 import carpet.utils.Messenger;
-import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
-import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import net.minecraft.SharedConstants;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.DimensionArgument;
-import net.minecraft.commands.arguments.GameModeArgument;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.commands.arguments.coordinates.RotationArgument;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.UUIDUtil;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.players.PlayerList;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.GameType;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec2;
-import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.InteractionHand;
+
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import static net.minecraft.commands.Commands.argument;
 import static net.minecraft.commands.Commands.literal;
-import static net.minecraft.commands.SharedSuggestionProvider.suggest;
 
 public class PlayerCommand
 {
-    // TODO: allow any order like execute
-    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext commandBuildContext)
+    private static final SimpleCommandExceptionType NOT_FAKE =
+            new SimpleCommandExceptionType(Component.literal("Only fake players can be targeted"));
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext ctx)
     {
-        LiteralArgumentBuilder<CommandSourceStack> command = literal("player")
-                .requires((player) -> CommandHelper.canUseCommand(player, CarpetSettings.commandPlayer))
-                .then(argument("player", StringArgumentType.word())
-                        .suggests((c, b) -> suggest(getPlayerSuggestions(c.getSource()), b))
-                        .then(literal("stop").executes(manipulation(EntityPlayerActionPack::stopAll)))
-                        .then(makeActionCommand("use", ActionType.USE))
-                        .then(makeActionCommand("jump", ActionType.JUMP))
-                        .then(makeActionCommand("attack", ActionType.ATTACK))
-                        .then(makeActionCommand("drop", ActionType.DROP_ITEM))
-                        .then(makeDropCommand("drop", false))
-                        .then(makeActionCommand("dropStack", ActionType.DROP_STACK))
-                        .then(makeDropCommand("dropStack", true))
-                        .then(makeActionCommand("swapHands", ActionType.SWAP_HANDS))
-                        .then(literal("hotbar")
-                                .then(argument("slot", IntegerArgumentType.integer(1, 9))
-                                        .executes(c -> manipulate(c, ap -> ap.setSlot(IntegerArgumentType.getInteger(c, "slot"))))))
-                        .then(literal("kill").executes(PlayerCommand::kill))
-                        .then(literal("disconnect").executes(PlayerCommand::disconnect))
-                        .then(literal("shadow"). executes(PlayerCommand::shadow))
-                        .then(literal("mount").executes(manipulation(ap -> ap.mount(true)))
-                                .then(literal("anything").executes(manipulation(ap -> ap.mount(false)))))
-                        .then(literal("dismount").executes(manipulation(EntityPlayerActionPack::dismount)))
-                        .then(literal("sneak").executes(manipulation(ap -> ap.setSneaking(true))))
-                        .then(literal("unsneak").executes(manipulation(ap -> ap.setSneaking(false))))
-                        .then(literal("sprint").executes(manipulation(ap -> ap.setSprinting(true))))
-                        .then(literal("unsprint").executes(manipulation(ap -> ap.setSprinting(false))))
-                        .then(literal("look")
-                                .then(literal("north").executes(manipulation(ap -> ap.look(Direction.NORTH))))
-                                .then(literal("south").executes(manipulation(ap -> ap.look(Direction.SOUTH))))
-                                .then(literal("east").executes(manipulation(ap -> ap.look(Direction.EAST))))
-                                .then(literal("west").executes(manipulation(ap -> ap.look(Direction.WEST))))
-                                .then(literal("up").executes(manipulation(ap -> ap.look(Direction.UP))))
-                                .then(literal("down").executes(manipulation(ap -> ap.look(Direction.DOWN))))
-                                .then(literal("at").then(argument("position", Vec3Argument.vec3())
-                                        .executes(c -> manipulate(c, ap -> ap.lookAt(Vec3Argument.getVec3(c, "position"))))))
-                                .then(argument("direction", RotationArgument.rotation())
-                                        .executes(c -> manipulate(c, ap -> ap.look(RotationArgument.getRotation(c, "direction").getRotation(c.getSource())))))
-                        ).then(literal("turn")
-                                .then(literal("left").executes(manipulation(ap -> ap.turn(-90, 0))))
-                                .then(literal("right").executes(manipulation(ap -> ap.turn(90, 0))))
-                                .then(literal("back").executes(manipulation(ap -> ap.turn(180, 0))))
-                                .then(argument("rotation", RotationArgument.rotation())
-                                        .executes(c -> manipulate(c, ap -> ap.turn(RotationArgument.getRotation(c, "rotation").getRotation(c.getSource())))))
-                        ).then(literal("move").executes(manipulation(EntityPlayerActionPack::stopMovement))
-                                .then(literal("forward").executes(manipulation(ap -> ap.setForward(1))))
-                                .then(literal("backward").executes(manipulation(ap -> ap.setForward(-1))))
-                                .then(literal("left").executes(manipulation(ap -> ap.setStrafing(1))))
-                                .then(literal("right").executes(manipulation(ap -> ap.setStrafing(-1))))
-                        ).then(literal("spawn").executes(PlayerCommand::spawn)
-                                .then(literal("in").requires((player) -> player.hasPermission(2))
-                                        .then(argument("gamemode", GameModeArgument.gameMode())
-                                        .executes(PlayerCommand::spawn)))
-                                .then(literal("at").then(argument("position", Vec3Argument.vec3()).executes(PlayerCommand::spawn)
-                                        .then(literal("facing").then(argument("direction", RotationArgument.rotation()).executes(PlayerCommand::spawn)
-                                                .then(literal("in").then(argument("dimension", DimensionArgument.dimension()).executes(PlayerCommand::spawn)
-                                                        .then(literal("in").requires((player) -> player.hasPermission(2))
-                                                                .then(argument("gamemode", GameModeArgument.gameMode())
-                                                                .executes(PlayerCommand::spawn)
-                                                        )))
-                                        )))
-                                ))
+        dispatcher.register(
+                literal("player")
+                        .requires(src -> CommandHelper.canUseCommand(src, CarpetSettings.commandPlayer))
+                        .then(argument("targets", EntityArgument.players())
+                                .then(literal("stop").executes(manipulation(EntityPlayerActionPack::stopAll)))
+                                .then(makeActionCommand("use", ActionType.USE))
+                                .then(makeActionCommand("jump", ActionType.JUMP))
+                                .then(makeActionCommand("attack", ActionType.ATTACK))
+                                .then(makeActionCommand("drop", ActionType.DROP_ITEM))
+                                .then(makeActionCommand("dropStack", ActionType.DROP_STACK))
+                                .then(makeActionCommand("swapHands", ActionType.SWAP_HANDS))
+                                .then(
+                                        makeSwingCommand())
+                                .then(literal("hotbar")
+                                        .then(argument("slot", IntegerArgumentType.integer(1, 9))
+                                                .executes(c -> manipulate(c,
+                                                        ap -> ap.setSlot(IntegerArgumentType.getInteger(c, "slot"))))))
+                                .then(literal("kill").executes(PlayerCommand::kill))
+                                .then(literal("disconnect").executes(PlayerCommand::disconnect))
+                                .then(literal("shadow").executes(PlayerCommand::shadow))
+                                .then(literal("mount")
+                                        .executes(manipulation(ap -> ap.mount(true)))
+                                        .then(literal("anything")
+                                                .executes(manipulation(ap -> ap.mount(false)))))
+                                .then(literal("dismount").executes(manipulation(EntityPlayerActionPack::dismount)))
+                                .then(literal("sneak").executes(manipulation(ap -> ap.setSneaking(true))))
+                                .then(literal("unsneak").executes(manipulation(ap -> ap.setSneaking(false))))
+                                .then(literal("sprint").executes(manipulation(ap -> ap.setSprinting(true))))
+                                .then(literal("unsprint").executes(manipulation(ap -> ap.setSprinting(false))))
+                                .then(literal("look")
+                                        .then(literal("north").executes(manipulation(ap -> ap.look(Direction.NORTH))))
+                                        .then(literal("south").executes(manipulation(ap -> ap.look(Direction.SOUTH))))
+                                        .then(literal("east").executes(manipulation(ap -> ap.look(Direction.EAST))))
+                                        .then(literal("west").executes(manipulation(ap -> ap.look(Direction.WEST))))
+                                        .then(literal("up").executes(manipulation(ap -> ap.look(Direction.UP))))
+                                        .then(literal("down").executes(manipulation(ap -> ap.look(Direction.DOWN))))
+                                        .then(literal("at")
+                                                .then(argument("position", Vec3Argument.vec3())
+                                                        .executes(c -> manipulate(c,
+                                                                ap -> ap.lookAt(Vec3Argument.getVec3(c, "position"))))))
+                                        .then(argument("direction", RotationArgument.rotation())
+                                                .executes(c -> manipulate(c,
+                                                        ap -> ap.look(RotationArgument.getRotation(c, "direction")
+                                                                .getRotation(c.getSource()))))))
                         )
-                );
-        dispatcher.register(command);
-    }
-
-    private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String actionName, ActionType type)
-    {
-        return literal(actionName)
-                .executes(manipulation(ap -> ap.start(type, Action.once())))
-                .then(literal("once").executes(manipulation(ap -> ap.start(type, Action.once()))))
-                .then(literal("continuous").executes(manipulation(ap -> ap.start(type, Action.continuous()))))
-                .then(literal("interval").then(argument("ticks", IntegerArgumentType.integer(1))
-                        .executes(c -> manipulate(c, ap -> ap.start(type, Action.interval(IntegerArgumentType.getInteger(c, "ticks")))))));
-    }
-
-    private static LiteralArgumentBuilder<CommandSourceStack> makeDropCommand(String actionName, boolean dropAll)
-    {
-        return literal(actionName)
-                .then(literal("all").executes(manipulation(ap -> ap.drop(-2, dropAll))))
-                .then(literal("mainhand").executes(manipulation(ap -> ap.drop(-1, dropAll))))
-                .then(literal("offhand").executes(manipulation(ap -> ap.drop(40, dropAll))))
-                .then(argument("slot", IntegerArgumentType.integer(0, 40)).
-                        executes(c -> manipulate(c, ap -> ap.drop(IntegerArgumentType.getInteger(c, "slot"), dropAll))));
-    }
-
-    private static Collection<String> getPlayerSuggestions(CommandSourceStack source)
-    {
-        //using s instead of @s because making it parse selectors properly was a pain in the ass
-        Set<String> players = new LinkedHashSet<>(List.of("Steve", "Alex", "TheobaldTheBot", "s"));
-        players.addAll(source.getOnlinePlayerNames());
-        return players;
-    }
-
-    private static ServerPlayer getPlayer(CommandContext<CommandSourceStack> context)
-    {
-        String playerName = StringArgumentType.getString(context, "player");
-        CommandSourceStack source = context.getSource();
-        MinecraftServer server = source.getServer();
-
-        //we can just use '/execute as' when we want proper target selectors
-        if (playerName.equals("s") && source.isPlayer()) return source.getPlayer();
-
-        return server.getPlayerList().getPlayerByName(playerName);
-    }
-
-    private static boolean cantManipulate(CommandContext<CommandSourceStack> context)
-    {
-        Player player = getPlayer(context);
-        CommandSourceStack source = context.getSource();
-        if (player == null)
-        {
-            Messenger.m(source, "r Can only manipulate existing players");
-            return true;
-        }
-        Player sender = source.getPlayer();
-        if (sender == null)
-        {
-            return false;
-        }
-
-        if (!source.getServer().getPlayerList().isOp(sender.getGameProfile()))
-        {
-            if (sender != player && !(player instanceof EntityPlayerMPFake))
-            {
-                Messenger.m(source, "r Non OP players can't control other real players");
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean cantReMove(CommandContext<CommandSourceStack> context)
-    {
-        if (cantManipulate(context)) return true;
-        Player player = getPlayer(context);
-        if (player instanceof EntityPlayerMPFake) return false;
-        Messenger.m(context.getSource(), "r Only fake players can be moved or killed");
-        return true;
-    }
-
-    private static boolean cantSpawn(CommandContext<CommandSourceStack> context)
-    {
-        String playerName = StringArgumentType.getString(context, "player");
-        MinecraftServer server = context.getSource().getServer();
-        PlayerList manager = server.getPlayerList();
-
-        if (EntityPlayerMPFake.isSpawningPlayer(playerName))
-        {
-            Messenger.m(context.getSource(), "r Player ", "rb " + playerName, "r  is currently logging on");
-            return true;
-        }
-        if (manager.getPlayerByName(playerName) != null)
-        {
-            Messenger.m(context.getSource(), "r Player ", "rb " + playerName, "r  is already logged on");
-            return true;
-        }
-        GameProfile profile = server.getProfileCache().get(playerName).orElse(null);
-        if (profile == null)
-        {
-            if (!CarpetSettings.allowSpawningOfflinePlayers)
-            {
-                Messenger.m(context.getSource(), "r Player "+playerName+" is either banned by Mojang, or auth servers are down. " +
-                        "Banned players can only be summoned in Singleplayer and in servers in off-line mode.");
-                return true;
-            } else {
-                profile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(playerName), playerName);
-            }
-        }
-        if (manager.getBans().isBanned(profile))
-        {
-            Messenger.m(context.getSource(), "r Player ", "rb " + playerName, "r  is banned on this server");
-            return true;
-        }
-        if (manager.isUsingWhitelist() && manager.isWhiteListed(profile) && !context.getSource().hasPermission(2))
-        {
-            Messenger.m(context.getSource(), "r Whitelisted players can only be spawned by operators");
-            return true;
-        }
-        return false;
-    }
-
-    private static int kill(CommandContext<CommandSourceStack> context) {
-        if (cantReMove(context)) return 0;
-        ServerPlayer player = getPlayer(context);
-        player.kill(player.serverLevel());
-        return 1;
-    }
-
-    private static int disconnect(CommandContext<CommandSourceStack> context) {
-        Player player = getPlayer(context);
-        if (player instanceof EntityPlayerMPFake)
-        {
-            ((EntityPlayerMPFake) player).fakePlayerDisconnect(Messenger.s(""));
-            return 1;
-        }
-        Messenger.m(context.getSource(), "r Cannot disconnect real players");
-        return 0;
-    }
-
-    @FunctionalInterface
-    interface SupplierWithCSE<T>
-    {
-        T get() throws CommandSyntaxException;
-    }
-
-    private static <T> T getArgOrDefault(SupplierWithCSE<T> getter, T defaultValue) throws CommandSyntaxException
-    {
-        try
-        {
-            return getter.get();
-        }
-        catch (IllegalArgumentException e)
-        {
-            return defaultValue;
-        }
-    }
-
-    private static int spawn(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
-    {
-        if (cantSpawn(context)) return 0;
-
-        CommandSourceStack source = context.getSource();
-        Vec3 pos = getArgOrDefault(
-                () -> Vec3Argument.getVec3(context, "position"),
-                source.getPosition()
         );
-        Vec2 facing = getArgOrDefault(
-                () -> RotationArgument.getRotation(context, "direction").getRotation(source),
-                source.getRotation()
-        );
-        ResourceKey<Level> dimType = getArgOrDefault(
-                () -> DimensionArgument.getDimension(context, "dimension").dimension(),
-                source.getLevel().dimension()
-        );
-        GameType mode = GameType.CREATIVE;
-        boolean flying = false;
-        if (source.getEntity() instanceof ServerPlayer sender)
-        {
-            mode = sender.gameMode.getGameModeForPlayer();
-            flying = sender.getAbilities().flying;
-        }
-        try {
-            mode = GameModeArgument.getGameMode(context, "gamemode");
-        } catch (IllegalArgumentException notPresent) {}
-
-        if (mode == GameType.SPECTATOR)
-        {
-            // Force override flying to true for spectator players, or they will fell out of the world.
-            flying = true;
-        } else if (mode.isSurvival())
-        {
-            // Force override flying to false for survival-like players, or they will fly too
-            flying = false;
-        }
-        String playerName = StringArgumentType.getString(context, "player");
-        if (playerName.length() > maxNameLength(source.getServer()))
-        {
-            Messenger.m(source, "rb Player name: " + playerName + " is too long");
-            return 0;
-        }
-
-        if (!Level.isInSpawnableBounds(BlockPos.containing(pos)))
-        {
-            Messenger.m(source, "rb Player " + playerName + " cannot be placed outside of the world");
-            return 0;
-        }
-        boolean success = EntityPlayerMPFake.createFake(playerName, source.getServer(), pos, facing.y, facing.x, dimType, mode, flying);
-        if (!success) {
-            Messenger.m(source, "rb Player " + playerName + " doesn't exist and cannot spawn in online mode. " +
-                    "Turn the server offline or the allowSpawningOfflinePlayers on to spawn non-existing players");
-            return 0;
-        };
-        return 1;
     }
 
-    private static int maxNameLength(MinecraftServer server)
+    private static List<EntityPlayerMPFake> requireFakeTargets(CommandContext<CommandSourceStack> context)
+            throws CommandSyntaxException
     {
-        return server.getPort() >= 0 ? SharedConstants.MAX_PLAYER_NAME_LENGTH : 40;
+        Collection<ServerPlayer> players = EntityArgument.getPlayers(context, "targets");
+        List<EntityPlayerMPFake> fakes = new ArrayList<>();
+
+        for (ServerPlayer p : players)
+        {
+            if (!(p instanceof EntityPlayerMPFake fake))
+                throw NOT_FAKE.create();
+            fakes.add(fake);
+        }
+
+        if (fakes.isEmpty())
+            throw NOT_FAKE.create();
+
+        return fakes;
     }
 
-    private static int manipulate(CommandContext<CommandSourceStack> context, Consumer<EntityPlayerActionPack> action)
+    private static int manipulate(CommandContext<CommandSourceStack> context,
+                                  Consumer<EntityPlayerActionPack> action)
+            throws CommandSyntaxException
     {
-        if (cantManipulate(context)) return 0;
-        ServerPlayer player = getPlayer(context);
-        action.accept(((ServerPlayerInterface) player).getActionPack());
+        for (EntityPlayerMPFake fake : requireFakeTargets(context))
+            action.accept(((ServerPlayerInterface) fake).getActionPack());
         return 1;
     }
 
@@ -344,22 +121,46 @@ public class PlayerCommand
         return c -> manipulate(c, action);
     }
 
-    private static int shadow(CommandContext<CommandSourceStack> context)
+    private static int kill(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
     {
-        if (cantManipulate(context)) return 0;
-
-        ServerPlayer player = getPlayer(context);
-        if (player instanceof EntityPlayerMPFake)
-        {
-            Messenger.m(context.getSource(), "r Cannot shadow fake players");
-            return 0;
-        }
-        if (player.getServer().isSingleplayerOwner(player.getGameProfile())) {
-            Messenger.m(context.getSource(), "r Cannot shadow single-player server owner");
-            return 0;
-        }
-
-        EntityPlayerMPFake.createShadow(player.server, player);
+        for (EntityPlayerMPFake fake : requireFakeTargets(context))
+            fake.kill(fake.serverLevel());
         return 1;
+    }
+
+    private static int disconnect(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+    {
+        for (EntityPlayerMPFake fake : requireFakeTargets(context))
+            fake.fakePlayerDisconnect(Messenger.s(""));
+        return 1;
+    }
+
+    private static int shadow(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+    {
+        requireFakeTargets(context);
+        return 0;
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String name, ActionType type)
+    {
+        return literal(name)
+                .executes(manipulation(ap -> ap.start(type, Action.once())))
+                .then(literal("once").executes(manipulation(ap -> ap.start(type, Action.once()))))
+                .then(literal("continuous").executes(manipulation(ap -> ap.start(type, Action.continuous()))));
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> makeSwingCommand()
+    {
+        return literal("swing")
+                .executes(manipulation(ap ->
+                        ap.start(ActionType.SWING, Action.swingOnce(null))))
+                .then(literal("mainhand")
+                        .executes(manipulation(ap ->
+                                ap.start(ActionType.SWING,
+                                        Action.swingOnce(InteractionHand.MAIN_HAND)))))
+                .then(literal("offhand")
+                        .executes(manipulation(ap ->
+                                ap.start(ActionType.SWING,
+                                        Action.swingOnce(InteractionHand.OFF_HAND)))));
     }
 }

--- a/src/main/java/carpet/commands/PlayerSpawnCommand.java
+++ b/src/main/java/carpet/commands/PlayerSpawnCommand.java
@@ -1,0 +1,110 @@
+package carpet.commands;
+
+import carpet.CarpetSettings;
+import carpet.patches.EntityPlayerMPFake;
+import com.mojang.authlib.GameProfile;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.SharedConstants;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.DimensionArgument;
+import net.minecraft.commands.arguments.GameModeArgument;
+import net.minecraft.commands.arguments.coordinates.Vec3Argument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.UUIDUtil;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static net.minecraft.commands.Commands.argument;
+import static net.minecraft.commands.Commands.literal;
+import static net.minecraft.commands.SharedSuggestionProvider.suggest;
+
+public class PlayerSpawnCommand
+{
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext ctx)
+    {
+        dispatcher.register(
+                literal("playerspawn")
+                        .requires(src -> src.hasPermission(2))
+                        .then(argument("player", StringArgumentType.word())
+                                .suggests((c, b) -> suggest(getNameSuggestions(c.getSource()), b))
+                                .executes(PlayerSpawnCommand::spawn)
+                                .then(literal("at")
+                                        .then(argument("position", Vec3Argument.vec3())
+                                                .executes(PlayerSpawnCommand::spawn)
+                                                .then(literal("in")
+                                                        .then(argument("gamemode", GameModeArgument.gameMode())
+                                                                .executes(PlayerSpawnCommand::spawn)
+                                                                .then(literal("on")
+                                                                        .then(argument("dimension",
+                                                                                DimensionArgument.dimension())
+                                                                                .executes(PlayerSpawnCommand::spawn)))))))
+                        ));
+    }
+
+    private static Set<String> getNameSuggestions(CommandSourceStack source)
+    {
+        Set<String> names = new LinkedHashSet<>();
+
+        names.add("Steve");
+        names.add("Alex");
+        names.add("TheobaldTheBot");
+
+        names.addAll(source.getOnlinePlayerNames());
+
+        return names;
+    }
+
+    private static int spawn(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
+    {
+        String name = StringArgumentType.getString(context, "player");
+        CommandSourceStack source = context.getSource();
+        MinecraftServer server = source.getServer();
+        PlayerList manager = server.getPlayerList();
+
+        if (manager.getPlayerByName(name) != null) return 0;
+        if (name.length() > maxNameLength(server)) return 0;
+
+        GameProfile profile = Objects.requireNonNull(server.getProfileCache()).get(name).orElse(null);
+        if (profile == null)
+        {
+            if (!CarpetSettings.allowSpawningOfflinePlayers) return 0;
+            profile = new GameProfile(UUIDUtil.createOfflinePlayerUUID(name), name);
+        }
+
+        Vec3 pos = context.getNodes().stream().anyMatch(n -> n.getNode().getName().equals("position"))
+                ? Vec3Argument.getVec3(context, "position")
+                : source.getPosition();
+
+        GameType mode = context.getNodes().stream().anyMatch(n -> n.getNode().getName().equals("gamemode"))
+                ? GameModeArgument.getGameMode(context, "gamemode")
+                : GameType.CREATIVE;
+
+        ResourceKey<Level> dim = context.getNodes().stream().anyMatch(n -> n.getNode().getName().equals("dimension"))
+                ? DimensionArgument.getDimension(context, "dimension").dimension()
+                : source.getLevel().dimension();
+
+        if (!Level.isInSpawnableBounds(BlockPos.containing(pos))) return 0;
+
+        EntityPlayerMPFake.createFake(
+                name, server, pos, source.getRotation().y, source.getRotation().x, dim, mode, true
+        );
+        return 1;
+    }
+
+    private static int maxNameLength(MinecraftServer server)
+    {
+        return server.getPort() >= 0 ? SharedConstants.MAX_PLAYER_NAME_LENGTH : 40;
+    }
+}

--- a/src/main/java/carpet/mixins/EntityDataAccessorMixin.java
+++ b/src/main/java/carpet/mixins/EntityDataAccessorMixin.java
@@ -1,0 +1,34 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.commands.data.EntityDataAccessor;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.UUID;
+
+@Mixin(EntityDataAccessor.class)
+
+public class EntityDataAccessorMixin {
+    @Shadow
+    @Final
+    private Entity entity;
+
+    @Inject(method = "setData", at = @At("HEAD"), cancellable = true)
+    void allowPlayerNbtSet(CompoundTag nbt, CallbackInfo ci) {
+        if (!CarpetSettings.editablePlayerNbt) return;
+        if (this.entity instanceof Player) {
+            UUID UUID = this.entity.getUUID();
+            this.entity.load(nbt);
+            this.entity.setUUID(UUID);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/carpet/mixins/EntityMixin.java
+++ b/src/main/java/carpet/mixins/EntityMixin.java
@@ -1,40 +1,92 @@
 package carpet.mixins;
 
+import carpet.CarpetSettings;
 import carpet.fakes.EntityInterface;
 import carpet.patches.EntityPlayerMPFake;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.network.protocol.game.ClientboundSetPassengersPacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
-public abstract class EntityMixin implements EntityInterface
-{
+public abstract class EntityMixin implements EntityInterface {
     @Shadow
     public float yRot;
-    
     @Shadow
     public float yRotO;
+    @Shadow
+    public Level level;
 
-    @Shadow public @Nullable abstract LivingEntity getControllingPassenger();
+    @Shadow
+    public @Nullable
+    abstract LivingEntity getControllingPassenger();
 
-    @Shadow public Level level;
+    @Final
+    private Entity self = (Entity) (Object) this;
 
     @Override
-    public float getMainYaw(float partialTicks)
-    {
+    public float getMainYaw(float partialTicks) {
         return partialTicks == 1.0F ? this.yRot : Mth.lerp(partialTicks, this.yRotO, this.yRot);
     }
 
     @Inject(method = "isLocalInstanceAuthoritative", at = @At("HEAD"), cancellable = true)
-    private void isFakePlayer(CallbackInfoReturnable<Boolean> cir)
-    {
-        if (getControllingPassenger() instanceof EntityPlayerMPFake) cir.setReturnValue(!level.isClientSide);
+    private void isFakePlayer(CallbackInfoReturnable<Boolean> cir) {
+        if (getControllingPassenger() instanceof EntityPlayerMPFake)
+            cir.setReturnValue(!level.isClientSide);
+    }
+
+    @Inject(method = "removePassenger", at = @At("TAIL"))
+    private void removePassengerForce(Entity passenger, CallbackInfo ci) {
+        if (!CarpetSettings.editablePlayerNbt) return;
+
+        if (!passenger.level().isClientSide && passenger instanceof ServerPlayer sp)
+            sp.connection.send(new ClientboundSetPassengersPacket(passenger));
+
+        if (!self.level().isClientSide && self instanceof ServerPlayer sp)
+            sp.connection.send(new ClientboundSetPassengersPacket(self));
+    }
+
+    @Inject(method = "addPassenger", at = @At("TAIL"))
+    private void addPassengerForce(Entity passenger, CallbackInfo ci) {
+        if (!CarpetSettings.editablePlayerNbt) return;
+
+        if (!passenger.level().isClientSide && passenger instanceof ServerPlayer sp)
+            sp.connection.send(new ClientboundSetPassengersPacket(passenger));
+
+        if (!self.level().isClientSide && self instanceof ServerPlayer sp)
+            sp.connection.send(new ClientboundSetPassengersPacket(self));
+    }
+
+    @WrapOperation(
+            method = "startRiding(Lnet/minecraft/world/entity/Entity;Z)Z",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/EntityType;canSerialize()Z"
+            )
+    )
+    private boolean allowPlayerRiding(
+            EntityType<?> type,
+            Operation<Boolean> original
+    ) {
+        if (!CarpetSettings.editablePlayerNbt)
+            return original.call(type);
+
+        if (type == EntityType.PLAYER)
+            return true;
+
+        return original.call(type);
     }
 }

--- a/src/main/java/carpet/mixins/RideCommandMixin.java
+++ b/src/main/java/carpet/mixins/RideCommandMixin.java
@@ -1,0 +1,28 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.server.commands.RideCommand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RideCommand.class)
+public class RideCommandMixin {
+
+    @Redirect(
+            method = "mount",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/Entity;getType()Lnet/minecraft/world/entity/EntityType;"
+            )
+    )
+    private static EntityType<?> allowPlayerMounts(Entity entity) {
+        EntityType<?> type = entity.getType();
+        if (type == EntityType.PLAYER && CarpetSettings.editablePlayerNbt) {
+            return EntityType.PIG; //Definitely a better way to do this I can't think of one tho
+        }
+        return type;
+    }
+}

--- a/src/main/java/carpet/mixins/ServerPlayer_fixPassengersMixin.java
+++ b/src/main/java/carpet/mixins/ServerPlayer_fixPassengersMixin.java
@@ -1,0 +1,22 @@
+package carpet.mixins;
+
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayer.class)
+public class ServerPlayer_fixPassengersMixin {
+    @Redirect(
+            method = "setGameMode",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/level/ServerPlayer;stopRiding()V"
+            )
+    )
+    private void fixPassengers(ServerPlayer player) {
+        if (!player.getPassengers().isEmpty()) {
+            player.ejectPassengers();
+        }
+    }
+}

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -39,7 +39,10 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractArrow;
 import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.entity.projectile.ThrowableItemProjectile;
+import net.minecraft.world.entity.projectile.ThrownEnderpearl;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.BlocksAttacks;
@@ -73,6 +76,7 @@ public class EntityPlayerMPFake extends ServerPlayer
     public boolean isAShadow;
     public Vec3 spawnPos;
     public double spawnYaw;
+    public double fakeFallDistance;
 
     // Returns true if it was successful, false if couldn't spawn due to the player not existing in Mojang servers
     public static boolean createFake(String username, MinecraftServer server, Vec3 pos, double yaw, double pitch, ResourceKey<Level> dimensionId, GameType gamemode, boolean flying)
@@ -131,7 +135,17 @@ public class EntityPlayerMPFake extends ServerPlayer
             server.getPlayerList().broadcastAll(ClientboundEntityPositionSyncPacket.of(instance), dimensionId);//instance.dimension);
             //instance.world.getChunkManager(). updatePosition(instance);
             instance.entityData.set(DATA_PLAYER_MODE_CUSTOMISATION, (byte) 0x7f); // show all model layers (incl. capes)
-            instance.getAbilities().flying = flying;
+            instance.getAbilities().mayfly =
+                    gamemode.isCreative() || gamemode == GameType.SPECTATOR;
+            instance.getAbilities().flying =
+                    gamemode.isCreative() || gamemode == GameType.SPECTATOR;
+
+            instance.onUpdateAbilities();
+
+            server.execute(() -> { //so it delays by a little
+                instance.setOnGround(false);
+                instance.setDeltaMovement(0.0D, instance.getDeltaMovement().y, 0.0D);
+            });
         }, server);
         return true;
     }
@@ -311,7 +325,7 @@ public class EntityPlayerMPFake extends ServerPlayer
             return false;
         }
         if (damageSource.getDirectEntity() instanceof ThrowableItemProjectile) {
-                return false;
+            return false;
         }
         if (this.isInvulnerableTo(serverLevel, damageSource)) {
             return false;

--- a/src/main/java/carpet/utils/DistanceCalculator.java
+++ b/src/main/java/carpet/utils/DistanceCalculator.java
@@ -19,45 +19,63 @@ public class DistanceCalculator
 
     public static List<Component> findDistanceBetweenTwoPoints(Vec3 pos1, Vec3 pos2)
     {
-        double dx = Mth.abs((float)pos1.x-(float)pos2.x);
-        double dy = Mth.abs((float)pos1.y-(float)pos2.y);
-        double dz = Mth.abs((float)pos1.z-(float)pos2.z);
-        double manhattan = dx+dy+dz;
-        double spherical = Math.sqrt(dx*dx + dy*dy + dz*dz);
-        double cylindrical = Math.sqrt(dx*dx + dz*dz);
+        double dx = Mth.abs((float)pos1.x - (float)pos2.x);
+        double dy = Mth.abs((float)pos1.y - (float)pos2.y);
+        double dz = Mth.abs((float)pos1.z - (float)pos2.z);
+
+        double manhattan = dx + dy + dz;
+        double spherical = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        double cylindrical = Math.sqrt(dx * dx + dz * dz);
+
         List<Component> res = new ArrayList<>();
-        res.add(Messenger.c("w Distance between ",
-                Messenger.tp("c",pos1),"w  and ",
-                Messenger.tp("c",pos2),"w :"));
+        res.add(Messenger.c(
+                "w Distance between ",
+                Messenger.tp("c", pos1),
+                "w  and ",
+                Messenger.tp("c", pos2),
+                "w :"
+        ));
         res.add(Messenger.c("w  - Spherical: ", String.format("wb %.2f", spherical)));
         res.add(Messenger.c("w  - Cylindrical: ", String.format("wb %.2f", cylindrical)));
         res.add(Messenger.c("w  - Manhattan: ", String.format("wb %.1f", manhattan)));
         return res;
     }
 
+    private static int sphericalDistance(Vec3 pos1, Vec3 pos2)
+    {
+        double dx = pos1.x - pos2.x;
+        double dy = pos1.y - pos2.y;
+        double dz = pos1.z - pos2.z;
+        return (int)Math.round(Math.sqrt(dx * dx + dy * dy + dz * dz));
+    }
+
     public static int distance(CommandSourceStack source, Vec3 pos1, Vec3 pos2)
     {
+        int spherical = sphericalDistance(pos1, pos2);
         Messenger.send(source, findDistanceBetweenTwoPoints(pos1, pos2));
-        return 1;
+        return spherical;
     }
 
     public static int setStart(CommandSourceStack source, Vec3 pos)
     {
         START_POINT_STORAGE.put(source.getTextName(), pos);
-        Messenger.m(source,"gi Initial point set to: ", Messenger.tp("g",pos));
+        Messenger.m(source, "gi Initial point set to: ", Messenger.tp("g", pos));
         return 1;
     }
 
     public static int setEnd(CommandSourceStack source, Vec3 pos)
     {
-        if ( !hasStartingPoint(source) )
+        if (!hasStartingPoint(source))
         {
             START_POINT_STORAGE.put(source.getTextName(), pos);
-            Messenger.m(source,"gi There was no initial point for "+source.getTextName());
-            Messenger.m(source,"gi Initial point set to: ", Messenger.tp("g",pos));
+            Messenger.m(source, "gi There was no initial point for " + source.getTextName());
+            Messenger.m(source, "gi Initial point set to: ", Messenger.tp("g", pos));
             return 0;
         }
-        Messenger.send(source, findDistanceBetweenTwoPoints( START_POINT_STORAGE.get(source.getTextName()), pos));
-        return 1;
+
+        Vec3 start = START_POINT_STORAGE.get(source.getTextName());
+        int spherical = sphericalDistance(start, pos);
+        Messenger.send(source, findDistanceBetweenTwoPoints(start, pos));
+        return spherical;
     }
 }

--- a/src/main/resources/carpet.accesswidener
+++ b/src/main/resources/carpet.accesswidener
@@ -13,6 +13,7 @@ accessible class net/minecraft/world/entity/player/Player
 #TODO fields and methods should be fetched via interfaces unless there is a good reason not to
 accessible method net/minecraft/world/level/border/WorldBorder getListeners ()Ljava/util/List;
 accessible method net/minecraft/world/level/redstone/DefaultRedstoneWireEvaluator calculateTargetStrength (Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)I
+accessible method net/minecraft/world/entity/LivingEntity getEffectiveGravity ()D
 
 #cause I don't want to deal with the interfaces until stuff is stable
 accessible method net/minecraft/world/level/block/entity/SkullBlockEntity fetchGameProfile (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -143,6 +143,7 @@
     "ServerLevel_scarpetMixin",
     "ServerLevel_tickMixin",
     "ServerPlayer_actionPackMixin",
+    "ServerPlayer_fixPassengersMixin",
     "ServerPlayer_scarpetEventMixin",
     "ServerPlayerGameMode_antiCheatMixin",
     "ServerPlayerGameMode_cactusMixin",

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -48,6 +48,7 @@
     "DynamicGraphMinFixedPoint_resetChunkInterface",
     "EndCrystal_scarpetEventsMixin",
     "Entity_scarpetEventsMixin",
+    "EntityDataAccessorMixin",
     "EntityMixin",
     "ExperienceOrb_xpNoCooldownMixin",
     "FallingBlockEntity_scarpetEventsMixin",

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -128,6 +128,7 @@
     "RandomState_ScarpetMixin",
     "RedstoneWireBlock_fastMixin",
     "ReloadCommand_reloadAppsMixin",
+    "RideCommandMixin",
     "SaplingBlock_desertShrubsMixin",
     "Scoreboard_scarpetMixin",
     "SculkSensorBlockEntityVibrationConfig_sculkSensorRangeMixin",


### PR DESCRIPTION
/distance returns a value that can be put into a score
yaw and pitch no longer reversed in /player look
Added a carpet settings (/carpet editablePlayerNbt [default false]) to be able to edit player nbt
Made /player use target selectors for ease of use in /execute commands
added /playerspawn to NOT use target selectors
Added /player swing [mainhand|offhand] to simulate the animation of placing/attacking 